### PR TITLE
Fix app seeding on deploy

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
-    "seed": "node seed/seed.js"
+    "seed": "node seed/seed.js",
+    "seed:if-empty": "node seed/seed-if-empty.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/backend/seed/seed-if-empty.js
+++ b/apps/backend/seed/seed-if-empty.js
@@ -1,0 +1,37 @@
+const dotenv = require('dotenv');
+const { connectToDatabase, disconnectFromDatabase } = require('../src/db');
+const Question = require('../src/models/Question');
+
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI;
+
+async function seedIfEmpty() {
+  if (!MONGODB_URI) {
+    throw new Error('MONGODB_URI must be set in environment');
+  }
+
+  await connectToDatabase(MONGODB_URI);
+
+  const existingCount = await Question.countDocuments();
+  if (existingCount > 0) {
+    // eslint-disable-next-line no-console
+    console.log(`Seed skipped: ${existingCount} questions already present.`);
+    await disconnectFromDatabase();
+    return;
+  }
+
+  const sampleQuestions = require('../src/sampleQuestions');
+
+  await Question.insertMany(sampleQuestions);
+  // eslint-disable-next-line no-console
+  console.log('Seeded sample questions (collection was empty).');
+  await disconnectFromDatabase();
+}
+
+seedIfEmpty().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Seed-if-empty failed:', error);
+  process.exit(1);
+});
+

--- a/render.yaml
+++ b/render.yaml
@@ -7,6 +7,7 @@ services:
     repo: https://example.com/your/repo.git
     buildCommand: cd apps/backend && npm ci || npm install
     startCommand: cd apps/backend && npm start
+    postDeployCommand: cd apps/backend && npm run seed:if-empty
     envVars:
       - key: NODE_ENV
         value: production


### PR DESCRIPTION
Add an idempotent seed script and configure Render to run it post-deploy to ensure the app seeds automatically.

The `seed:if-empty` script ensures that sample data is only inserted if the `Question` collection is empty, preventing duplicate data on subsequent deploys.

---
<a href="https://cursor.com/background-agent?bcId=bc-935d754c-6a29-4eaa-b7cf-3eda30baa998">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-935d754c-6a29-4eaa-b7cf-3eda30baa998">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

